### PR TITLE
✨ Add config stores (#29)

### DIFF
--- a/argdantic/__init__.py
+++ b/argdantic/__init__.py
@@ -3,7 +3,7 @@
 from argdantic.core import ArgParser
 from argdantic.fields import ArgField
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __all__ = [
     "ArgParser",
     "ArgField",

--- a/argdantic/stores/__init__.py
+++ b/argdantic/stores/__init__.py
@@ -1,0 +1,11 @@
+from argdantic.stores.base import SettingsStoreCallable
+from argdantic.stores.json import JsonSettingsStore
+from argdantic.stores.toml import TomlSettingsStore
+from argdantic.stores.yaml import YamlSettingsStore
+
+__all__ = [
+    "JsonSettingsStore",
+    "SettingsStoreCallable",
+    "TomlSettingsStore",
+    "YamlSettingsStore",
+]

--- a/argdantic/stores/base.py
+++ b/argdantic/stores/base.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Callable, Optional, Set, Union
+
+from pydantic import BaseSettings
+
+SettingsStoreCallable = Callable[["BaseSettings"], None]
+
+
+class BaseSettingsStore(ABC):
+    """
+    A settings store is a callable object that takes an input file path
+    and stores settings to it in a specific format, given by the implementation.
+    """
+
+    def __init__(
+        self,
+        path: Union[str, Path],
+        *,
+        encoding: str = "utf-8",
+        include: Set[str] = None,
+        exclude: Set[str] = None,
+        by_alias: bool = False,
+        skip_defaults: Optional[bool] = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False,
+    ) -> None:
+        self.path = Path(path)
+        self.encoding = encoding
+        self.include = include
+        self.exclude = exclude
+        self.by_alias = by_alias
+        self.skip_defaults = skip_defaults
+        self.exclude_unset = exclude_unset
+        self.exclude_defaults = exclude_defaults
+        self.exclude_none = exclude_none
+
+    @abstractmethod
+    def __call__(self, settings: BaseSettings) -> None:
+        raise NotImplementedError  # pragma: no cover

--- a/argdantic/stores/json.py
+++ b/argdantic/stores/json.py
@@ -1,0 +1,26 @@
+from pydantic import BaseSettings
+
+from argdantic.stores.base import BaseSettingsStore
+
+
+class JsonSettingsStore(BaseSettingsStore):
+    """
+    A JSON file settings store writes settings to a JSON file.
+    Orjson is used if available, otherwise the standard json module is used.
+    """
+
+    def __call__(self, settings: BaseSettings) -> None:
+        with self.path.open("wb") as f:
+            text = settings.json(
+                include=self.include,
+                exclude=self.exclude,
+                by_alias=self.by_alias,
+                skip_defaults=self.skip_defaults,
+                exclude_unset=self.exclude_unset,
+                exclude_defaults=self.exclude_defaults,
+                exclude_none=self.exclude_none,
+            )
+            f.write(text.encode(self.encoding))
+
+    def __repr__(self) -> str:
+        return f"<JsonSettingsStore path={self.path}>"

--- a/argdantic/stores/toml.py
+++ b/argdantic/stores/toml.py
@@ -1,0 +1,35 @@
+from pydantic import BaseSettings
+
+from argdantic.stores.base import BaseSettingsStore
+
+
+class TomlSettingsStore(BaseSettingsStore):
+    """
+    A TOML file settings store writes settings to a TOML file.
+    Tomli is used if available, otherwise the standard toml module is used.
+    """
+
+    def __call__(self, settings: BaseSettings) -> None:
+        try:
+            import toml
+        except ImportError:
+            raise ImportError(
+                "You need to install TOML dependencies to use the TOML source. "
+                "You can do so by running `pip install argdantic[toml]`."
+            )
+
+        with self.path.open("wb") as f:
+            text = toml.dumps(
+                settings.dict(
+                    include=self.include,
+                    exclude=self.exclude,
+                    by_alias=self.by_alias,
+                    skip_defaults=self.skip_defaults,
+                    exclude_unset=self.exclude_unset,
+                    exclude_defaults=self.exclude_defaults,
+                )
+            )
+            f.write(text.encode(self.encoding))
+
+    def __repr__(self) -> str:
+        return f"<TomlSettingsStore path={self.path}>"

--- a/argdantic/stores/yaml.py
+++ b/argdantic/stores/yaml.py
@@ -1,0 +1,34 @@
+from pydantic import BaseSettings
+
+from argdantic.stores.base import BaseSettingsStore
+
+
+class YamlSettingsStore(BaseSettingsStore):
+    """
+    A YAML file settings store writes settings to a YAML file.
+    PyYAML is used if available, otherwise the standard yaml module is used.
+    """
+
+    def __call__(self, settings: BaseSettings) -> None:
+        try:
+            import yaml
+        # exception actually tested, but coverage does not detect it
+        except ImportError:  # pragma: no cover
+            raise ImportError(
+                "You need to install YAML dependencies to use the YAML store. "
+                "You can do so by running `pip install argdantic[yaml]`."
+            )
+
+        with self.path.open("w") as f:
+            data = settings.dict(
+                include=self.include,
+                exclude=self.exclude,
+                by_alias=self.by_alias,
+                skip_defaults=self.skip_defaults,
+                exclude_unset=self.exclude_unset,
+                exclude_defaults=self.exclude_defaults,
+            )
+            yaml.safe_dump(data, f, encoding="utf-8", allow_unicode=True)
+
+    def __repr__(self) -> str:
+        return f"<YamlSettingsStore path={self.path}>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ src_paths = ["argdantic", "tests"]
 ignore = ["E741"]
 max-line-length = 120
 
+[tool.ruff]
+line-length = 120
+
 [tool.pytest.ini_options]
 addopts = "-ra --capture=sys"
 log_cli = true

--- a/tests/test_stores/test_json.py
+++ b/tests/test_stores/test_json.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from pydantic import BaseSettings
+
+from argdantic.stores import JsonSettingsStore
+from argdantic.testing import CLIRunner
+
+
+def test_json_store_repr(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    store = JsonSettingsStore(path)
+    assert store.path == path
+    assert repr(store) == f"<JsonSettingsStore path={path}>"
+
+
+def test_json_store_call(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    store = JsonSettingsStore(path)
+    assert store.path == path
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+
+    store(Settings())
+    assert path.read_text() == '{"foo": "baz", "bar": 42}'
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+        baz: List[str] = ["foo", "bar"]
+
+    store(Settings())
+    assert path.read_text() == '{"foo": "baz", "bar": 42, "baz": ["foo", "bar"]}'
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+        baz: List[str] = ["foo", "bar"]
+        qux: Set[str] = {"foo", "bar"}
+
+    store(Settings())
+    text = path.read_text()
+    data = json.loads(text)
+    assert data["foo"] == "baz"
+    assert data["bar"] == 42
+    assert all(item in data["baz"] for item in ["foo", "bar"])
+    assert all(item in data["qux"] for item in ["foo", "bar"])
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+        baz: List[str] = ["foo", "bar"]
+        qux: Set[str] = {"foo", "bar"}
+        quux: Dict[str, Any] = {"foo": "bar"}
+
+    store(Settings())
+    text = path.read_text()
+    data = json.loads(text)
+    assert data["foo"] == "baz"
+    assert data["bar"] == 42
+    assert all(item in data["baz"] for item in ["foo", "bar"])
+    assert all(item in data["qux"] for item in ["foo", "bar"])
+    assert data["quux"] == {"foo": "bar"}
+
+
+def test_parser_using_json_store(tmp_path: Path, runner: CLIRunner) -> None:
+    from argdantic import ArgParser
+
+    cli = ArgParser()
+    path = tmp_path / "settings.json"
+
+    @cli.command(stores=[JsonSettingsStore(path)])
+    def main(foo: str = "baz", bar: int = 42) -> None:
+        return foo, bar
+
+    result = runner.invoke(cli, [])
+    assert result.exception is None
+    assert result.return_value == ("baz", 42)

--- a/tests/test_stores/test_toml.py
+++ b/tests/test_stores/test_toml.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import mock
+import pytest
+from pydantic import BaseSettings
+
+from argdantic.testing import CLIRunner
+
+
+def test_toml_store_repr(tmp_path: Path) -> None:
+    from argdantic.stores.toml import TomlSettingsStore
+
+    path = tmp_path / "settings.toml"
+    store = TomlSettingsStore(path)
+    assert store.path == path
+    assert repr(store) == f"<TomlSettingsStore path={path}>"
+
+
+def test_toml_store_import_error(tmp_path: Path) -> None:
+    from argdantic.stores.toml import TomlSettingsStore
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+
+    with mock.patch.dict("sys.modules", {"toml": None}):
+        store = TomlSettingsStore(tmp_path / "settings.toml")
+        assert repr(store) == f"<TomlSettingsStore path={store.path}>"
+        with pytest.raises(ImportError):
+            store(Settings())
+
+
+def test_toml_store_call(tmp_path: Path) -> None:
+    from argdantic.stores.toml import TomlSettingsStore
+
+    path = tmp_path / "settings.toml"
+    store = TomlSettingsStore(path)
+    assert store.path == path
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+
+    store(Settings())
+    # read data, remove trailing newline and trailing whitespace
+    data = path.read_text().strip().replace("\n", " ")
+    assert data == 'foo = "baz" bar = 42'
+    assert data == 'foo = "baz" bar = 42'
+
+
+def test_parser_using_toml_store(tmp_path: Path, runner: CLIRunner) -> None:
+    from argdantic import ArgParser
+    from argdantic.stores.toml import TomlSettingsStore
+
+    path = tmp_path / "settings.toml"
+    parser = ArgParser()
+
+    @parser.command(stores=[TomlSettingsStore(path)])
+    def main(foo: str = "baz", bar: int = 42) -> None:
+        return foo, bar
+
+    result = runner.invoke(parser, [])
+    assert result.exception is None
+    assert result.return_value == ("baz", 42)

--- a/tests/test_stores/test_yaml.py
+++ b/tests/test_stores/test_yaml.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import mock
+import pytest
+from pydantic import BaseSettings
+
+from argdantic.testing import CLIRunner
+
+
+def test_yaml_store_import_error(tmp_path: Path) -> None:
+    from argdantic.stores.yaml import YamlSettingsStore
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+
+    with mock.patch.dict("sys.modules", {"yaml": None}):
+        store = YamlSettingsStore(tmp_path / "settings.yaml")
+        assert repr(store) == f"<YamlSettingsStore path={store.path}>"
+        assert isinstance(store, YamlSettingsStore)
+        with pytest.raises(Exception):
+            data = Settings()
+            store(data)
+
+
+def test_yaml_store_repr(tmp_path: Path) -> None:
+    from argdantic.stores.yaml import YamlSettingsStore
+
+    path = tmp_path / "settings.yaml"
+    store = YamlSettingsStore(path)
+    assert store.path == path
+    assert repr(store) == f"<YamlSettingsStore path={path}>"
+
+
+def test_yaml_store_call(tmp_path: Path) -> None:
+    from argdantic.stores.yaml import YamlSettingsStore
+
+    path = tmp_path / "settings.yaml"
+    store = YamlSettingsStore(path)
+    assert store.path == path
+
+    class Settings(BaseSettings):
+        foo: str = "baz"
+        bar: int = 42
+
+    store(Settings())
+    # read data, remove trailing newline and trailing whitespace
+    data = path.read_text().strip().replace("\n", " ")
+    assert data == "bar: 42 foo: baz"
+
+
+def test_parser_using_yaml_store(tmp_path: Path, runner: CLIRunner) -> None:
+    from argdantic import ArgParser
+    from argdantic.stores.yaml import YamlSettingsStore
+
+    path = tmp_path / "settings.yaml"
+    parser = ArgParser()
+
+    @parser.command(stores=[YamlSettingsStore(path)])
+    def main(foo: str = "baz", bar: int = 42) -> None:
+        return foo, bar
+
+    result = runner.invoke(parser, [])
+    assert result.exception is None
+    assert result.return_value == ("baz", 42)
+
+    result = runner.invoke(parser, ["--foo", "qux"])
+    assert result.exception is None
+    assert result.return_value == ("qux", 42)
+    assert result.return_value == ("qux", 42)


### PR DESCRIPTION
Add configuration stores, that mirror the source functionality by storing the full inputs to a file.
Similarly, stores support JSON, YAML, and TOML. 